### PR TITLE
Add image sharing

### DIFF
--- a/objects/secret.rb
+++ b/objects/secret.rb
@@ -15,24 +15,32 @@ class Secret
 
   DATA_KEYS = %i[
     message
+    type
     is_ttl
     email
     notify
   ]
 
-  attr_accessor :message, :ttl, :email
+  MESSAGE_TYPES = {
+    :text => "text",
+    :image => "image"
+  }
+
+  attr_accessor :message, :type, :ttl, :email
 
   def self.from_redis(data, expiry)
     new data[:message],
+      type: data[:type],
       ttl: to_minutes(expiry),
       is_ttl: bool(data[:is_ttl]),
       notify: bool(data[:notify]),
       email: data[:email]
   end
 
-  def initialize(message, ttl: TIMES.values.max, is_ttl: false, notify: false, email: nil)
+  def initialize(message, type: nil, ttl: TIMES.values.max, is_ttl: false, notify: false, email: nil)
     @message = message
 
+    @type = type
     @is_ttl = is_ttl
     @ttl = (auto_expire? ? ttl.to_i : TIMES.values.max)  # force an auto expire of max time
 
@@ -63,6 +71,7 @@ class Secret
   def to_h
     {
       message: message,
+      type: type,
       is_ttl: auto_expire?,
       email: email,
       notify: notify?

--- a/public/authoring.js
+++ b/public/authoring.js
@@ -5,6 +5,10 @@ $(document).ready(function() {
   $timeSelect = $("#expire-time")
   $times = $(".select-wrapper")
   $flash = $("#flash")
+  $message = $("#message")
+  $secretImage = $("#secret-image")
+  $messageTypes = $("input[name=secret-type]") // Radio button group
+  $optionsLabel = $("#options-label")
 
   function toggleTimeSelect(evt) {
     $times.toggle($timeSelect.is(":checked"));
@@ -14,13 +18,33 @@ $(document).ready(function() {
     $email.toggle($notifySelect.is(":checked"));
   }
 
+  function toggleMessageType(evt) {
+    displayMessageType($(this).val());
+  }
+
+  function displayMessageType(type) {
+    if (type == "image") {
+      $message.hide();
+      // Required for file input styling, which uses the :valid pseudo-class
+      $("#secret-image input[name=secret-image]").prop("required", true);
+      $secretImage.show();
+    } else {
+      $secretImage.hide();
+      // Remove attribute from this hidden element so the form will validate 
+      $("#secret-image input[name=secret-image]").prop("required", false);
+      $message.show();
+    }
+  }
+
   $readSelect.on("click", toggleTimeSelect);
   $timeSelect.on("click", toggleTimeSelect);
   $notifySelect.on("click", toggleEmail);
+  $messageTypes.on("click", toggleMessageType);
 
   setTimeout(function() {
     $flash.hide('slow');
   }, 2000);
 
   $("#note").focus();
+  $("#type-message").prop("checked", true); // Default on load/reload
 });

--- a/public/reading.js
+++ b/public/reading.js
@@ -1,14 +1,41 @@
 $(document).ready(function() {
+  var mtype;
+
+  $title = $("#title")
   $note = $("#note")
+  $image = $("#display-secret-image")
   $ttl = $("#ttl")
+  $info = $(".info")
 
   $.ajax("/note/" + $note.data('nid'), {contentType: "application/json"})
     .done(function(data) {
-      $note.text(data.note);
-      $ttl.text("This note will be destroyed " + data.ttl + ".").show();
+      // Undestroyed "legacy" notes without a type should be considered text
+      if (!data.type || data.type == "text") {
+        $image.hide();
+        $title.text("Here's your note");
+        $note.text(data.note);
+        $note.show();
+        mtype = "note";
+      } else {
+        $note.hide();
+        $title.text("Here's your image");
+        $image.attr("src", data.note);
+        $image.show();
+        mtype = "image";
+      }
 
+      $ttl.text("This "
+        + mtype
+        + " will be destroyed "
+        + data.ttl
+        + ".").show();
+
+      $info.text("If it's important, save this "
+        + mtype
+        + " somewhere secure. Once the "
+        + mtype
+        + " expires, we can't retrieve it for you.")
     }).fail(function(xhr, status, error) {
       window.location = "/read/not_found"
     });
-
 });

--- a/public/styles.css
+++ b/public/styles.css
@@ -157,3 +157,7 @@ nav {
 .info {
   padding: 20px 0;
 }
+
+#display-secret-image {
+  border: 0;
+}

--- a/public/upload.css
+++ b/public/upload.css
@@ -1,0 +1,46 @@
+/* https://scribblerockerz.com/drag-n-drop-file-input-without-javascript/ */
+
+/* File upload area styles */
+
+#secret-image {
+  display: none;
+  margin-bottom: 10px;
+  width: 100%;
+  position: relative;
+}
+#secret-image input[type=file] {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+#secret-image .file-dummy {
+  width: 100%;
+  padding: 30px;
+  background: rgba(255, 255, 255, 0.2);
+  border: 2px dashed rgba(105, 203, 243, 1);
+  text-align: center;
+  transition: background 0.3s ease-in-out;
+}
+#secret-image .file-dummy .success {
+  display: none;
+}
+#secret-image:hover .file-dummy {
+  background: rgba(255, 255, 255, 0.1);
+}
+#secret-image input[type=file]:focus + .file-dummy {
+  outline: 2px solid rgba(255, 255, 255, 0.5);
+  outline: -webkit-focus-ring-color auto 5px;
+}
+#secret-image input[type=file]:valid + .file-dummy {
+  border-color: rgba(105, 203, 243, 1);
+  background-color: rgba(204, 238, 253, 1);
+}
+#secret-image input[type=file]:valid + .file-dummy .success {
+  display: inline-block;
+}

--- a/services/image_encoder.rb
+++ b/services/image_encoder.rb
@@ -1,0 +1,11 @@
+require 'base64'
+require 'open-uri'
+
+class ImageEncoder
+  def self.encode(image_path, ext)
+    content = open(image_path) { |f| f.read }
+    encoded = Base64.encode64(content)
+
+    image = "data:image/#{ext};base64,#{encoded}"
+  end
+end

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -8,6 +8,7 @@
     %link{ rel: "stylesheet", href: "/vendor/bootstrap.min.css" }
     %link{ rel: "stylesheet", href: "/articons.css" }
     %link{ rel: "stylesheet", href: "/styles.css" }
+    %link{ rel: "stylesheet", href: "/upload.css" }
 
   %body
     %header

--- a/views/read.haml
+++ b/views/read.haml
@@ -1,11 +1,10 @@
-%h2 Here's your note
+%h2#title
 
 %pre#note{ data: { nid: key } } ...
-
+%img#display-secret-image{ data: { nid: key } }
 #ttl
 
 .info
-  If it's important, save this note somewhere secure. Once the note expires, we can't retrieve it for you.
 
 - content_for :js do
   %script{ src: "/reading.js" }

--- a/views/write.haml
+++ b/views/write.haml
@@ -1,10 +1,25 @@
-%form{ action: "/save", method: "POST" }
+%form{ action: "/save", method: "POST", enctype: "multipart/form-data" }
+
+  %h4 Share a new:
+  .radio
+    %label
+      %input.radio#type-message{ type: "radio", name: "secret-type", value: :text, checked: :checked }
+      Message
+    %label
+      %input.radio#type-image{ type: "radio", name: "secret-type", value: :image }
+      Image
 
   #message.form-group
     %label{ for: "text" } Message:
     %textarea#note{ name: "text", rows: "12" }
 
-  %label{ for: "options" } This message will self-destruct:
+  #secret-image
+    %input{ type: "file", name: "secret-image", id: "images" }
+    .file-dummy
+      .success Image selected, click 'Share' to save
+      .default Please click or drag and drop here to select an image file
+
+  %label#options-label{ for: "options" } This message will self-destruct:
   #options.form-group
     .radio
       %label


### PR DESCRIPTION
This change would add image sharing via the method suggested in #36.

Secrets would now be typed as `text` or `image`. Images are base64 encoded, and their corresponding tempfiles are deleted immediately afterward. (If upgrading, any yet-undestroyed messages should be treated as text-types in the absence of a type attribute in the hash structure.)