### PR TITLE
Update rack to 2.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     ordo (0.0.2)
     public_suffix (2.0.5)
     puma (3.11.3)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-json-logs (1.1)
       colorize
       json
@@ -147,4 +147,4 @@ DEPENDENCIES
   tilt (~> 2.0)
 
 BUNDLED WITH
-   1.16.4
+   1.17.1


### PR DESCRIPTION
Like it say on the tin

Addresses https://nvd.nist.gov/vuln/detail/CVE-2018-16470