### PR TITLE
Remove sqreen

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem 'sinatra-contrib'
 gem 'rack-flash3', git: 'https://github.com/treeder/rack-flash'
 gem 'http'
 gem 'tilt', "~>2.0"
-gem 'sqreen', '>= 1.16'
 
 group :development do
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,6 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.4.1)
       launchy (~> 2.2)
-    libsqreen (0.3.0.0.3)
     loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -112,10 +111,6 @@ GEM
       rack-protection (= 2.0.3)
       sinatra (= 2.0.3)
       tilt (>= 1.3, < 3)
-    sq_mini_racer (0.2.5.0.1.beta3)
-    sqreen (1.18.6)
-      libsqreen (~> 0.3.0.0)
-      sq_mini_racer (~> 0.2.4.sqreen2)
     temple (0.8.2)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -148,7 +143,6 @@ DEPENDENCIES
   shotgun
   sinatra (~> 2.0.3)
   sinatra-contrib
-  sqreen (>= 1.16)
   tilt (~> 2.0)
 
 BUNDLED WITH


### PR DESCRIPTION
We've decided to stop using the Sqreen service for now. This PR removes their library from Shush. 